### PR TITLE
Fix wordle logic

### DIFF
--- a/tutorial/wordle_server.c
+++ b/tutorial/wordle_server.c
@@ -10,8 +10,9 @@
  * we will actually randomise the word the user is guessing.
  */
 char word[WORD_LENGTH] = { 'h', 'e', 'l', 'l', 'o' };
+enum character_state states[WORD_LENGTH] = { INCORRECT };
 
-bool is_character_in_word(char *word, int ch) {
+bool char_in_word(char *word, char ch) {
     for (int i = 0; i < WORD_LENGTH; i++) {
         if (word[i] == ch) {
             return true;
@@ -21,13 +22,28 @@ bool is_character_in_word(char *word, int ch) {
     return false;
 }
 
-enum character_state char_to_state(int ch, char *word, uint64_t index) {
-    if (ch == word[index]) {
-        return CORRECT_PLACEMENT;
-    } else if (is_character_in_word(word, ch)) {
-        return INCORRECT_PLACEMENT;
-    } else {
-        return INCORRECT;
+void calculate_states(char *word, char *guess , enum character_state *states) {
+    int counts[26] = { 0 };
+
+    for (int i = 0; i < WORD_LENGTH; i++) {
+        counts[word[i] - 'a']++;
+    }
+
+    for (int i = 0; i < WORD_LENGTH; i++) {
+        if (guess[i] == word[i]) {
+            states[i] = CORRECT_PLACEMENT;
+            counts[guess[i] - 'a']--;
+        } else {
+            states[i] = INCORRECT;
+        }
+    }
+
+    for (int i = 0; i < WORD_LENGTH; i++) {
+        if (guess[i] != word[i] && char_in_word(word, guess[i])
+            && counts[guess[i] - 'a'] > 0) {
+            states[i] = INCORRECT_PLACEMENT;
+            counts[guess[i] - 'a']--;
+        }
     }
 }
 


### PR DESCRIPTION
The current logic in `wordle_server.c` is incorrect. If a misplaced letter keeps appearing more than the number of times it has appeared in the target word, it should not keep showing as yellow.

Example 1:
```
word:     hello
guess:    eeeee
output:   YGYYY
correct:  XGXXX
```
Example 2:
```
word:     hello
guess:    lelel
output:   YGGYY
correct:  YGGXX
```
Where `Y` is yellow, `G` is green, and `X` is grey.

Concerns are:
* It might be confusing to have to call the `calculate_states` function then pack MRs using the `states` global
* Not sure if static alphabet sized array and lines like `counts[word[i] - 'a']++` is clear enough