### PR TITLE
details: avoid 4-space indent for markdown

### DIFF
--- a/website/src/part1.md
+++ b/website/src/part1.md
@@ -58,13 +58,13 @@ to be able to access anything unless we explicitly allow it. This is allowed by 
 in seL4 are modelled by capabilities. If a PD does not have the capability to some resource, seL4 does not allow it to use it!
 
 <details>
-    <summary>What is a capability? (click to expand)</summary>
-    Whenever you open a file on UNIX-like operating systems, the kernel gives you a file-descriptor. A unique token that
-    is used to refer to that file from now on. Say if you want to read or write or close the file, you have to use the
-    file-descriptor. You can think of capabilities as similar to file-descriptors except that it is for every kind of
-    object in seL4. For example if you wanted a thread to have access to a certain page of memory, it must have the
-    capability to that page. If you want multiple threads to communicate (as we'll see later), each thread must
-    also have capabilities to the communication objects (such as Endpoints and Notifications in seL4).
+  <summary>What is a capability? (click to expand)</summary>
+  Whenever you open a file on UNIX-like operating systems, the kernel gives you a file-descriptor. A unique token that
+  is used to refer to that file from now on. Say if you want to read or write or close the file, you have to use the
+  file-descriptor. You can think of capabilities as similar to file-descriptors except that it is for every kind of
+  object in seL4. For example if you wanted a thread to have access to a certain page of memory, it must have the
+  capability to that page. If you want multiple threads to communicate (as we'll see later), each thread must
+  also have capabilities to the communication objects (such as Endpoints and Notifications in seL4).
 </details>
 
 #### Entry points


### PR DESCRIPTION
Avoid 4-space indent in the `<details>` block so that markdown does not render the content as a code block. This seems to only happen on the Jekyll renderer, not in mdbook itself.

(The docsite will translate `<details>` to `<details markdown="1">`)
