### PR TITLE
Add an extra target triplet in tutorial/Makefile for Nix development shells

### DIFF
--- a/solutions/Makefile
+++ b/solutions/Makefile
@@ -10,11 +10,14 @@ ifndef TOOLCHAIN
 	# Get whether the common toolchain triples exist
 	TOOLCHAIN_AARCH64_LINUX_GNU := $(shell command -v aarch64-linux-gnu-gcc 2> /dev/null)
 	TOOLCHAIN_AARCH64_UNKNOWN_LINUX_GNU := $(shell command -v aarch64-unknown-linux-gnu-gcc 2> /dev/null)
+	TOOLCHAIN_AARCH64_NONE_ELF := $(shell command -v aarch64-none-elf-gcc 2> /dev/null)
 	# Then check if they are defined and select the appropriate one
 	ifdef TOOLCHAIN_AARCH64_LINUX_GNU
 		TOOLCHAIN := aarch64-linux-gnu
 	else ifdef TOOLCHAIN_AARCH64_UNKNOWN_LINUX_GNU
 		TOOLCHAIN := aarch64-unknown-linux-gnu
+	else ifdef TOOLCHAIN_AARCH64_NONE_ELF
+		TOOLCHAIN := aarch64-none-elf
 	else
 		$(error "Could not find an AArch64 cross-compiler")
 	endif

--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -10,11 +10,14 @@ ifndef TOOLCHAIN
 	# Get whether the common toolchain triples exist
 	TOOLCHAIN_AARCH64_LINUX_GNU := $(shell command -v aarch64-linux-gnu-gcc 2> /dev/null)
 	TOOLCHAIN_AARCH64_UNKNOWN_LINUX_GNU := $(shell command -v aarch64-unknown-linux-gnu-gcc 2> /dev/null)
+	TOOLCHAIN_AARCH64_NONE_ELF := $(shell command -v aarch64-none-elf-gcc 2> /dev/null)
 	# Then check if they are defined and select the appropriate one
 	ifdef TOOLCHAIN_AARCH64_LINUX_GNU
 		TOOLCHAIN := aarch64-linux-gnu
 	else ifdef TOOLCHAIN_AARCH64_UNKNOWN_LINUX_GNU
 		TOOLCHAIN := aarch64-unknown-linux-gnu
+	else ifdef TOOLCHAIN_AARCH64_NONE_ELF
+		TOOLCHAIN := aarch64-none-elf
 	else
 		$(error "Could not find an AArch64 cross-compiler")
 	endif


### PR DESCRIPTION
The pkgsCross.aarch64-embedded set, as used in this project's flake.nix, supplies an embedded toolchain that uses the aarch64-none-elf target triplet. This change enables users to build the tutorial code in the project's Nix development shell without supplying extra environment variables.